### PR TITLE
AirGrid RTD Provider: update audience segmentation data setting method for the  Ortb2 bidder config

### DIFF
--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -8,7 +8,6 @@
 import { config } from '../src/config.js';
 import { submodule } from '../src/hook.js';
 import {
-  mergeDeep,
   deepSetValue,
   deepAccess,
 } from '../src/utils.js';
@@ -85,13 +84,24 @@ function setAudiencesToAppNexusAdUnits(adUnits, audiences) {
  * @param {Array} audiences
  * @return {{}} a map from bidder code to ORTB2 config
  */
-export function getAudiencesAsBidderOrtb2(rtdConfig, audiences) {
+export function setAudiencesAsBidderOrtb2(rtdConfig, audiences) {
   const bidders = deepAccess(rtdConfig, 'params.bidders');
-  if (!bidders || bidders.length === 0) return {};
-  const agOrtb2 = {}
-  deepSetValue(agOrtb2, 'ortb2.user.ext.data.airgrid', audiences || []);
+  if (!bidders || bidders.length === 0 || !audiences || audiences.length === 0) return;
 
-  return Object.fromEntries(bidders.map(bidder => [bidder, agOrtb2]));
+  const keywords = audiences.map(
+    (audienceId) => `perid=${audienceId}`
+  ).join(',');
+
+  config.mergeBidderConfig({
+    bidders: bidders,
+    config: {
+      ortb2: {
+        site: {
+          keywords,
+        }
+      }
+    }
+  })
 }
 
 export function setAudiencesUsingAppNexusAuctionKeywords(audiences) {
@@ -131,7 +141,7 @@ export function passAudiencesToBidders(
   const audiences = getMatchedAudiencesFromStorage();
   if (audiences.length > 0) {
     setAudiencesUsingAppNexusAuctionKeywords(audiences);
-    mergeDeep(bidConfig?.ortb2Fragments?.bidder, getAudiencesAsBidderOrtb2(rtdConfig, audiences));
+    setAudiencesAsBidderOrtb2(rtdConfig, audiences)
     if (adUnits) {
       setAudiencesToAppNexusAdUnits(adUnits, audiences);
     }

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -110,12 +110,18 @@ describe('airgrid RTD Submodule', function () {
         .withArgs(agRTD.AG_AUDIENCE_IDS_KEY)
         .returns(JSON.stringify(MATCHED_AUDIENCES));
       const audiences = agRTD.getMatchedAudiencesFromStorage();
-      const bidderOrtb2 = agRTD.getAudiencesAsBidderOrtb2(RTD_CONFIG.dataProviders[0], audiences);
 
-      const bidders = RTD_CONFIG.dataProviders[0].params.bidders;
+      agRTD.setAudiencesAsBidderOrtb2(RTD_CONFIG.dataProviders[0], audiences);
+
+      const bidderConfig = config.getBidderConfig()
+      const bidders = RTD_CONFIG.dataProviders[0].params.bidders
+      const bidderOrtb2 = bidderConfig
+
       Object.keys(bidderOrtb2).forEach((bidder) => {
         if (bidders.indexOf(bidder) === -1) return;
-        expect(deepAccess(bidderOrtb2[bidder], 'ortb2.user.ext.data.airgrid')).to.eql(MATCHED_AUDIENCES);
+        MATCHED_AUDIENCES.forEach((audience) => {
+          expect(deepAccess(bidderOrtb2[bidder], 'ortb2.site.keywords')).to.contain(audience);
+        })
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

Updates the way in how the AirGrid RTD adapter module passes audience segmentation information to the bidder config settings.
Solves a problem caused by breaking changes in the dependency modules.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@ydennisy 