### PR TITLE
chore: use provided tag insertion method

### DIFF
--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -13,6 +13,7 @@ import {
 } from '../src/utils.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { loadExternalScript } from '../src/adloader.js';
 
 const MODULE_NAME = 'realTimeData';
 const SUBMODULE_NAME = 'airgrid';
@@ -24,6 +25,10 @@ export const storage = getStorageManager({
   moduleName: SUBMODULE_NAME,
 });
 
+function getModuleUrl(publisherId) {
+  return `https://cdn.edkt.io/${publisherId}/edgekit.min.js`;
+}
+
 /**
  * Attach script tag to DOM
  * @param {Object} rtdConfig
@@ -32,19 +37,13 @@ export const storage = getStorageManager({
 export function attachScriptTagToDOM(rtdConfig) {
   var edktInitializor = (window.edktInitializor = window.edktInitializor || {});
   if (!edktInitializor.invoked) {
-    edktInitializor.invoked = true;
-    edktInitializor.accountId = rtdConfig.params.accountId;
-    edktInitializor.publisherId = rtdConfig.params.publisherId;
-    edktInitializor.apiKey = rtdConfig.params.apiKey;
-    edktInitializor.load = function (e) {
-      var p = e || 'sdk';
-      var n = document.createElement('script');
-      n.type = 'module';
-      n.async = true;
-      n.src = 'https://cdn.edkt.io/' + p + '/edgekit.min.js';
-      document.getElementsByTagName('head')[0].appendChild(n);
-    };
-    edktInitializor.load(edktInitializor.accountId);
+    const moduleSrc = getModuleUrl(rtdConfig.params.publisherId);
+    loadExternalScript(moduleSrc, SUBMODULE_NAME, () => {
+      edktInitializor.invoked = true;
+      edktInitializor.accountId = rtdConfig.params.accountId;
+      edktInitializor.publisherId = rtdConfig.params.publisherId;
+      edktInitializor.apiKey = rtdConfig.params.apiKey;
+    });
   }
 }
 

--- a/modules/airgridRtdProvider.js
+++ b/modules/airgridRtdProvider.js
@@ -26,7 +26,8 @@ export const storage = getStorageManager({
 });
 
 function getModuleUrl(publisherId) {
-  return `https://cdn.edkt.io/${publisherId}/edgekit.min.js`;
+  const path = publisherId ?? 'sdk';
+  return `https://cdn.edkt.io/${path}/edgekit.min.js`;
 }
 
 /**

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -22,7 +22,8 @@ const _approvedLoadExternalJSList = [
   'improvedigital',
   'aaxBlockmeter',
   'confiant',
-  'arcspan'
+  'arcspan',
+  'airgrid'
 ]
 
 /**

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -2,6 +2,7 @@ import { config } from 'src/config.js';
 import { deepAccess } from 'src/utils.js';
 import { getAdUnits } from '../../fixtures/fixtures.js';
 import * as agRTD from 'modules/airgridRtdProvider.js';
+import { loadExternalScript } from '../../../src/adloader.js';
 
 const MATCHED_AUDIENCES = ['travel', 'sport'];
 const RTD_CONFIG = {
@@ -40,6 +41,7 @@ describe('airgrid RTD Submodule', function () {
       expect(agRTD.airgridSubmodule.init(RTD_CONFIG.dataProviders[0])).to.equal(
         true
       );
+      expect(loadExternalScript.called).to.be.true
     });
 
     it('should attach script to DOM with correct config', function () {


### PR DESCRIPTION
# Summary

Closes https://github.com/AirGrid/rmap/issues/1459

## Type of change

- [x] Bugfix

## Description of change

Use `loadExternalScript` instead of custom code for tag module loading

## Other information

@ydennisy
